### PR TITLE
[#13989]Create a shared config npm package

### DIFF
--- a/lib/shuttlerock_shared_config/version.rb
+++ b/lib/shuttlerock_shared_config/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShuttlerockSharedConfig
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/tasks/tasks.rb
+++ b/lib/tasks/tasks.rb
@@ -13,7 +13,7 @@ namespace :shuttlerock_shared_config do
     FileUtils.copy(input_path, Dir.pwd)
   end
 
-  desc 'Update .eslint.yml'
+  desc 'Update .eslintrc'
   task :update_eslint do
     input_path = File.expand_path('../../lib/templates/.eslintrc', __dir__)
     FileUtils.copy(input_path, Dir.pwd)

--- a/lib/tasks/update_eslintrc.js
+++ b/lib/tasks/update_eslintrc.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+// .eslintrc will be created or overwritten by default.
+fs.copyFile(__dirname + '/../templates/.eslintrc', '.eslintrc', (err) => {
+    if (err) throw err;
+    console.log('.eslintrc was copied to the project');
+});

--- a/lib/templates/.eslintrc
+++ b/lib/templates/.eslintrc
@@ -30,6 +30,8 @@
     "jest": true,
     "Routes": true,
     "window": true,
+    "MIXPANEL_TOKEN": true,
+    "beforeAll": true
   },
   "rules": {
     "class-methods-use-this": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "shuttlerock_shared_config",
+  "version": "0.2.2",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "shuttlerock_shared_config",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Update shared config for Shuttlerock's projects.",
-  "main": "update_all.js",
-  "directories": {
-    "lib": "lib"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "bin": {
+    "update_eslintrc": "./lib/tasks/update_eslintrc.js"
   },
   "repository": {
     "type": "git",
@@ -18,5 +17,6 @@
   "bugs": {
     "url": "https://github.com/Shuttlerock/shuttlerock_shared_config/issues"
   },
-  "homepage": "https://github.com/Shuttlerock/shuttlerock_shared_config#readme"
+  "homepage": "https://github.com/Shuttlerock/shuttlerock_shared_config#readme",
+  "dependencies": {}
 }

--- a/update_all.js
+++ b/update_all.js
@@ -1,7 +1,0 @@
-const fs = require('fs');
-
-// .eslintrc will be created or overwritten by default.
-fs.copyFile(__dirname+'/templates/.eslintrc', '.eslintrc', (err) => {
-  if (err) throw err;
-  console.log('.eslintrc was successfully copied');
-});


### PR DESCRIPTION
## Create a shared config npm package

[Trello Card](https://trello.com/c/MRucYfvj/13989-create-a-shared-config-npm-package)

As discussed in the dev meeting - for use in projects without a Gemfile. Ideally we would use the same git repository and same template files, so we only have to maintain them in one place.


## How to test the PR
For JS App run:
```
npm run-script update_eslintrc
```
or

```
yarn run update_eslintrc
```
In main JS app need to add line to package.json:
scripts: {
...
  "update_eslintrc": "npx update_eslintrc"
...
}



## Deployment Notes

no

