### PR TITLE
Upgrade to ruby 2.6.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 defaults: &defaults
   working_directory: ~/shuttlerock_shared_config
   docker:
-    - image: circleci/ruby:2.6.3-node
+    - image: circleci/ruby:2.6.5-node
 
 version: 2
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 
 # rspec failure tracking
 .rspec_status
+.ruby-gemset
+.ruby-version
 
 # bundler
 .bundle

--- a/shuttlerock_shared_config.gemspec
+++ b/shuttlerock_shared_config.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib`.split(/\s+/)
   spec.bindir        = 'exe'
 
-  spec.required_ruby_version = '>= 2.6.3'
+  spec.required_ruby_version = '>= 2.6.5'
 
   spec.add_dependency 'rake', '~> 12.3'
   spec.add_dependency 'rubocop', '~> 0.64'


### PR DESCRIPTION
## Upgrade to ruby 2.6.5

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/26818)

See: https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/

## How to test the PR

-

## Deployment Notes

-
