### PR TITLE
Remove warning message from rubocop

### DIFF
--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'vendor/**/*'
 
 # Align the elements of a hash literal if they span more than one line.
-AlignHash:
+Layout/AlignHash:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -42,13 +42,13 @@ AlignHash:
   #   bb: 1
   EnforcedColonStyle: table
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
-EmptyLines:
+Layout/EmptyLines:
   Enabled: false
 
-LineLength:
+Metrics/LineLength:
   Max: 150
 
 Metrics/AbcSize:
@@ -74,10 +74,10 @@ Naming/UncommunicativeMethodParamName:
 Naming/UncommunicativeBlockParamName:
   MinNameLength: 2
 
-SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
 
-SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
## Remove warning message from rubocop

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/27098)

.rubocop.yml: Warning: no department given for AlignHash.
.rubocop.yml: Warning: no department given for Documentation.
.rubocop.yml: Warning: no department given for EmptyLines.
.rubocop.yml: Warning: no department given for LineLength.
.rubocop.yml: Warning: no department given for SpaceInsideParens.
.rubocop.yml: Warning: no department given for SpaceBeforeFirstArg.

## How to test the PR

-

## Deployment Notes

-
