### PR TITLE
Add new cops to rubocop.yml

### DIFF
--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -42,6 +42,9 @@ Layout/HashAlignment:
   #   bb: 1
   EnforcedColonStyle: table
 
+Rails/ApplicationController:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 
@@ -74,11 +77,24 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+#Checks method call operators to not have spaces around them.
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Layout/SpaceInsideParens:
   Enabled: false
 
 Layout/SpaceBeforeFirstArg:
   Enabled: false
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Style/AccessModifierDeclarations:
   Enabled: false
@@ -90,11 +106,20 @@ Style/ClassAndModuleChildren:
   Enabled:       true
   EnforcedStyle: compact
 
-Layout/EmptyLinesAroundBlockBody:
+Style/ExponentialNotation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
 
 Style/RedundantReturn:
   Enabled: false


### PR DESCRIPTION
## Add new cops to rubocop.yml

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/54771)

The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
Metrics/LineLength has the wrong namespace - should be Layout
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/

## How to test the PR

-

## Deployment Notes

-
