### PR TITLE
Need to add new cops to .rubocop.yml

### DIFF
--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -77,7 +77,16 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
 Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
   Enabled: false
 
 #Checks method call operators to not have spaces around them.
@@ -123,6 +132,15 @@ Style/HashTransformValues:
 
 Style/RedundantReturn:
   Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: true
 
 Style/TrailingCommaInArguments:
   Enabled:                   true


### PR DESCRIPTION
## Need to add new cops to .rubocop.yml

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/57810)

The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Lint/DeprecatedOpenSSLConstant (0.84)
 - Lint/MixedRegexpCaptureTypes (0.85)
 - Style/RedundantRegexpCharacterClass (0.85)
 - Style/RedundantRegexpEscape (0.85)
 - Style/SlicingWithRange (0.83)

## How to test the PR

-

## Deployment Notes

none
