### PR TITLE
Add new cops to rubocop.yml

### DIFF
--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -45,6 +45,15 @@ Layout/HashAlignment:
 Rails/ApplicationController:
   Enabled: true
 
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
+Rails/WhereNot:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 
@@ -77,7 +86,31 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/EmptyFile:
+  Enabled: true
+
+Lint/IdentityComparison:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/UselessMethodDefinition:
+  Enabled: true
+
+Lint/UselessTimes:
+  Enabled: true
+
+Layout/BeginEndAlignment:
   Enabled: true
 
 Layout/EmptyLinesAroundBlockBody:
@@ -115,6 +148,9 @@ Style/ClassAndModuleChildren:
   Enabled:       true
   EnforcedStyle: compact
 
+Style/CombinableLoops:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: false
 
@@ -130,6 +166,9 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Style/KeywordParametersOrder:
+  Enabled: true
+
 Style/RedundantReturn:
   Enabled: false
 
@@ -139,7 +178,13 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: false
 
+Style/RedundantSelfAssignment:
+  Enabled: true
+
 Style/SlicingWithRange:
+  Enabled: true
+
+Style/SoleNestedConditional:
   Enabled: true
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
## Add new cops to rubocop.yml

[Clubhouse Story](https://app.clubhouse.io/shuttlerock/story/75163)

The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Layout/BeginEndAlignment: # (new in 0.91)
  Enabled: true
Lint/ConstantDefinitionInBlock: # (new in 0.91)
  Enabled: true
Lint/DuplicateRequire: # (new in 0.90)
  Enabled: true
Lint/EmptyFile: # (new in 0.90)
  Enabled: true
Lint/IdentityComparison: # (new in 0.91)
  Enabled: true
Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
  Enabled: true
Lint/UselessMethodDefinition: # (new in 0.90)
  Enabled: true
Lint/UselessTimes: # (new in 0.91)
  Enabled: true
Style/CombinableLoops: # (new in 0.90)
  Enabled: true
Style/KeywordParametersOrder: # (new in 0.90)
  Enabled: true
Style/RedundantSelfAssignment: # (new in 0.90)
  Enabled: true
Style/SoleNestedConditional: # (new in 0.89)
  Enabled: true
Performance/Sum: # (new in 1.8)
  Enabled: true
Rails/AfterCommitOverride: # (new in 2.8)
  Enabled: true
Rails/SquishedSQLHeredocs: # (new in 2.8)
  Enabled: true
Rails/WhereNot: # (new in 2.8)
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html

## How to test the PR

- How to test feature 1
  - Do this
  - Do that
  - Success
- How to test feature 2
- How to test feature 3

## Deployment Notes

It requires new Environmental variables:

- `EXAMPLE_ENV_VARIABLE=content`
- `EXAMPLE_ENV_VARIABLE2=content`
