### PR TITLE
[ORANGE-1219] Check/update circleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,12 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
+version: 2.1
 
 defaults: &defaults
   working_directory: ~/shuttlerock_shared_config
   docker:
-    - image: circleci/ruby:2.6.6-node
+    - image: cimg/ruby:2.6.6-node
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD
-
-version: 2.1
 
 orbs:
   jira: circleci/jira@1.3.0
@@ -27,7 +22,8 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
             - ./vendor/bundle


### PR DESCRIPTION
## [ORANGE-1219] Check/update circleCI images

[Clubhouse Story](https://shuttlerock.atlassian.net/browse/ORANGE-1219)


Email:

> Your organization is receiving this email because there are still legacy convenience images being used. These images are being deprecated in two rounds - the first round was on December 31, 2021. They will not be deleted, but they will no longer be supported. You should have received emails about the specific images in September/October of last year.
> 
> Some images and tags have undergone significant changes and there may be some configuration changes that need to be made beyond the image name. For a list of affected images and tags, please take a look at [our Discuss post about the deprecation](http://gslink.circleci.com/ls/click?upn=2xX95wS72SYPIyQ6OjEQpX6b5-2Fd-2Bif2FUWbzNf8tGbomdM39u-2F3wa1zvPqY5B8JIXH7nMEuOGYyxEfGPp2K1uC6HaX1AZXn-2Fz9iTRwlttZIPS9NAa5LSdAIhrjRkKkpQhwEk_042kFAsge-2Bx7f4QL62BPQLObfUD1lExgjyDxR2iOmh6bVZTlAPC3om4utAnJ7fcDZBhc0Ub2XwMKFiPkB-2Fu201xuYKXHqXIekDvuvcy0csdl98TRYbjZCrMcbEb6QQlvy-2BNJPfcWSdXmd5gcVLA8Ygm4uuwF49sJXTPSyxuLKU1dJ-2Bjf-2BIVjMRhDWzaXdygCBpqLtH3OazHKT9Snv7bhGUluAKvKpvcOG3ICz-2BLXWYTnBaz0TEDtXh4r8j5LGRWiYnWnMT0DuwKwazU8oa51vw7A751Guk6x0uFCYkJQ5ir0eYLIMMWB6guz-2FWsvhYZl-2BKVeBsX5lIwbVTuBmik7oczQ7ROj3vFWk4ORT5pimOwdzPT-2Fv8zIx20n4nK03k9sxa4Rudy8YRGNzim5Zad-2F7Vg1JKOtYSXvc0XAHzdEQo7Cx2KpwKch6ozKJs8JspKzYbHfF7qjkjVpaPJfU8qStsO2S4s9UbTv4bX3jOfQahs-3D). If your team runs into any issues during this upgrade process, please reach out to me and we can set up a meeting with one of our DevOps Customer Engineers to assist.
> 
> If you have any questions, any feedback about the new images, or would like to set up a meeting to discuss, please let me know.

## How to test the PR

- How to test feature 1
  - CI pass

## Deployment Notes

none

[ORANGE-1219]: https://shuttlerock.atlassian.net/browse/ORANGE-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ