### PR TITLE
Update gem version to 0.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/shuttlerock_shared_config
   docker:
-    - image: cimg/ruby:2.6.6-node
+    - image: cimg/ruby:3.0.2-node
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ### Changed
 
+## 0.3.0 (2022-05-23)
+
+- Updated required ruby version to ~> 3.0.0
+- Updated rubocop version to allow current ~> 1.0 version
+- Updated rake version to allow current ~> 13.0 version
+- Add dependabot config
+- Add github actions workflow
+- Fix github PR template
+- Update CircleCI image names
+- Update rubocop config:
+  - Add new cops
+  - Add rubocop-rspec
+  - Enable new cops
+  - Target ruby v3
+
 ## 0.2.32 (2020-10-01)
 
 ### Changed
@@ -48,9 +63,7 @@
 
 ## 0.2.31 (2020-09-08)
 
-Updated minimum version requirements for gems
-
-### Changed
+- Updated minimum version requirements for gems
 
 ## 0.2.30 (2020-06-18)
 

--- a/lib/shuttlerock_shared_config/version.rb
+++ b/lib/shuttlerock_shared_config/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShuttlerockSharedConfig
-  VERSION = '0.2.32'
+  VERSION = '0.3.0'
 end

--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -268,6 +268,9 @@ Style/ExplicitBlockArgument:
 Style/ExponentialNotation:
   Enabled: false
 
+Style/FetchEnvVar:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -2,9 +2,11 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.6
+  NewCops: enable
+  TargetRubyVersion: 3.0
   Exclude:
     - 'app/admin/**/*.rb'
     - 'bin/**/*'
@@ -12,6 +14,7 @@ AllCops:
     - 'db/schema.rb'
     - 'db/migrate/**/*'
     - 'lib/tasks/**/*'
+    - 'node_modules/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
 
@@ -42,18 +45,6 @@ Layout/HashAlignment:
   #   bb: 1
   EnforcedColonStyle: table
 
-Rails/ApplicationController:
-  Enabled: true
-
-Rails/AfterCommitOverride:
-  Enabled: true
-
-Rails/SquishedSQLHeredocs:
-  Enabled: true
-
-Rails/WhereNot:
-  Enabled: true
-
 Style/Documentation:
   Enabled: false
 
@@ -62,6 +53,36 @@ Layout/EmptyLines:
 
 Layout/LineLength:
   Max: 150
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
 
 Metrics/AbcSize:
   Enabled: true
@@ -86,6 +107,9 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
+Naming/VariableNumber:
+  EnforcedStyle: normalcase
+
 Lint/ConstantDefinitionInBlock:
   Enabled: true
 
@@ -95,11 +119,20 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/DuplicateRequire:
   Enabled: true
 
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Lint/EmptyFile:
   Enabled: true
 
 Lint/IdentityComparison:
   Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
 
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
@@ -112,15 +145,6 @@ Lint/UselessTimes:
 
 Layout/BeginEndAlignment:
   Enabled: true
-
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: false
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
 
 #Checks method call operators to not have spaces around them.
 Layout/SpaceAroundMethodCallOperator:
@@ -138,11 +162,98 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Performance/AncestorsInclude:
+  Enabled: true
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/ApplicationController:
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/WhereNot:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: true
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: true
+
+Rails/NegateInclude:
+  Enabled: true
+
+Rails/Pluck:
+  Enabled: true
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: true
+
+Rails/WhereExists:
+  Enabled: true
+
 Style/AccessModifierDeclarations:
   Enabled: false
 
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
 Style/BlockDelimiters:
   Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled:       true
@@ -151,13 +262,25 @@ Style/ClassAndModuleChildren:
 Style/CombinableLoops:
   Enabled: true
 
+Style/ExplicitBlockArgument:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
 
 Style/HashEachMethods:
+  Enabled: true
+
+Style/HashLikeCase:
   Enabled: true
 
 Style/HashTransformKeys:
@@ -169,6 +292,21 @@ Style/HashTransformValues:
 Style/KeywordParametersOrder:
   Enabled: true
 
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantSelfAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
 Style/RedundantReturn:
   Enabled: false
 
@@ -178,13 +316,16 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: false
 
-Style/RedundantSelfAssignment:
+Style/SingleArgumentDig:
   Enabled: true
 
 Style/SlicingWithRange:
   Enabled: true
 
 Style/SoleNestedConditional:
+  Enabled: true
+
+Style/StringConcatenation:
   Enabled: true
 
 Style/TrailingCommaInArguments:
@@ -205,4 +346,34 @@ Style/AndOr:
 # https://github.com/codeclimate/codeclimate-rubocop/blob/master/base_rubocop.yml#L71
 # We use %w[ ], not %w( ) because the former looks like an array
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 70
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MessageChain:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 25
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 10
+
+RSpec/StubbedMock:
+  Enabled: false
+
+RSpec/ContextWording:
   Enabled: false

--- a/lib/templates/PULL_REQUEST_TEMPLATE.md
+++ b/lib/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,60 @@
-## Clubhouse Card Name Here
+[JIRA Story Link]( www.add-link-here )
 
-[Clubhouse Story](link-here)
+Copy and paste JIRA description here
 
-Description from the Clubhouse story
+## Type of change
+Select all that apply:
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Security issue
+- [ ] Infrastructure / network
+- [ ] Refactoring
+- [ ] Functional improvement
+
+## What changed?
+
+#### Before
+
+（エラーの）条件があれば、ここに書いてください。
+You clicked a button and it gave error
+
+#### After
+
+開発後の結果
+When you click the button, it does the thing.
+
 
 ## How to test the PR
 
-- How to test feature 1
-  - Do this
-  - Do that
-  - Success
-- How to test feature 2
-- How to test feature 3
+#### Preparation: 
+テスト用の条件、準備を書いてください。
+Prepare something before tests
+
+#### Tests
+Some page > Subpage (どこでテストをします)
+
+- Select something　（やること）
+- Click button　（やること）
+  - Success when something happens　（結果）
+
+Add screenshot if applicable　（スクショ）
+
+- Select something else　（やること）
+- Click button　（やること）
+  - Success when something else happens　（結果）
+
+Add screenshot if applicable　（スクショ）
+
+---
+
+**Regression:** If there were any substantial changes to view layer code (CSS, JS) or Javascript dependencies were updated do a general smoke test of the feature using the following Windows 7 browsers on Browser Stack. If Chrome only is chosen, only Chrome is tested normally without any other browsers.
+
+Chromeだけが選択だったら、他のブラウザーのテストは不要です。
+
+- [x] Chrome (Latest)
+- [ ] Firefox (Latest)
+- [ ] Internet Explorer 11
 
 ## Deployment Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shuttlerock_shared_config",
-  "version": "0.2.32",
+  "version": "0.3.0",
   "description": "Update shared config for Shuttlerock's projects.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/shuttlerock_shared_config.gemspec
+++ b/shuttlerock_shared_config.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib`.split(/\s+/)
   spec.bindir        = 'exe'
 
-  spec.required_ruby_version = '>= 2.6.6'
+  spec.required_ruby_version = '~> 3.0.0'
 
-  spec.add_dependency 'rake', '>= 12.3', '< 14.0'
-  spec.add_dependency 'rubocop', '>= 0.88', '< 2.0'
+  spec.add_dependency 'rake', '~> 13.0'
+  spec.add_dependency 'rubocop', '~> 1.29'
   spec.add_dependency 'danger', '~> 8.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
# Update gem version to 0.3.0

## New:

- Updated required ruby version to ~> 3.0.0
- Fix github PR template
- Update rubocop config:
  - Add new cops
  - Add rubocop-rspec
  - Enable new cops
  - Target ruby v3

## Previously changed (not published yet):


- Updated rubocop version to allow current ~> 1.0 version
- Updated rake version to allow current ~> 13.0 version
- Add dependabot config
- Add github actions workflow
- Update CircleCI image names

## Deployment Notes

none