### PR TITLE
Gem version 0.3.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,12 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
+version: 2.1
 
 defaults: &defaults
   working_directory: ~/shuttlerock_shared_config
   docker:
-    - image: circleci/ruby:2.6.6-node
+    - image: cimg/ruby:2.6.6-node
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD
-
-version: 2.1
 
 orbs:
   jira: circleci/jira@1.3.0
@@ -27,7 +22,8 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
             - ./vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/shuttlerock_shared_config
   docker:
-    - image: cimg/ruby:2.6.6-node
+    - image: cimg/ruby:3.0.2-node
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+registries:
+  rubygems-server-gem-fury-io-h-app71456489:
+    type: rubygems-server
+    url: https://gem.fury.io/h_app71456489/
+    token: "${{secrets.RUBYGEMS_SERVER_GEM_FURY_IO_H_APP71456489_TOKEN}}"
+
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "16:00"
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 20
+  registries:
+  - rubygems-server-gem-fury-io-h-app71456489

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  rubygems-server-gem-fury-io-h-app71456489:
-    type: rubygems-server
-    url: https://gem.fury.io/h_app71456489/
-    token: "${{secrets.RUBYGEMS_SERVER_GEM_FURY_IO_H_APP71456489_TOKEN}}"
-
 updates:
 - package-ecosystem: bundler
   directory: "/"
@@ -14,5 +8,11 @@ updates:
   pull-request-branch-name:
     separator: "-"
   open-pull-requests-limit: 20
-  registries:
-  - rubygems-server-gem-fury-io-h-app71456489
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "16:00"
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 20

--- a/.github/workflows/check-suite-completed-action.yml
+++ b/.github/workflows/check-suite-completed-action.yml
@@ -1,14 +1,14 @@
-name: 'Check run completed'
+name: 'Check suite completed'
 on:
-  check_run:
+  check_suite:
     types: [completed]
 
 jobs:
-  check_run_completed_action:
+  check_suite_completed_action:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: Shuttlerock/actions/actions/check-run-completed-action@master
+      - uses: Shuttlerock/actions/actions/check-suite-completed-action@master
         with:
           credentials-api-prefix: ${{ secrets.CREDENTIALS_API_PREFIX }}
           credentials-api-secret: ${{ secrets.CREDENTIALS_API_SECRET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ### Changed
 
+## 0.3.0 (2022-05-23)
+
+- Updated required ruby version to ~> 3.0.0
+- Updated rubocop version to allow current ~> 1.0 version
+- Updated rake version to allow current ~> 13.0 version
+- Add dependabot config
+- Add github actions workflow
+- Fix github PR template
+- Update CircleCI image names
+- Update rubocop config:
+  - Add new cops
+  - Add rubocop-rspec
+  - Enable new cops
+  - Target ruby v3
+
 ## 0.2.32 (2020-10-01)
 
 ### Changed
@@ -48,9 +63,7 @@
 
 ## 0.2.31 (2020-09-08)
 
-Updated minimum version requirements for gems
-
-### Changed
+- Updated minimum version requirements for gems
 
 ## 0.2.30 (2020-06-18)
 

--- a/lib/shuttlerock_shared_config/version.rb
+++ b/lib/shuttlerock_shared_config/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShuttlerockSharedConfig
-  VERSION = '0.2.32'
+  VERSION = '0.3.0'
 end

--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -268,6 +268,9 @@ Style/ExplicitBlockArgument:
 Style/ExponentialNotation:
   Enabled: false
 
+Style/FetchEnvVar:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/lib/templates/.rubocop.yml
+++ b/lib/templates/.rubocop.yml
@@ -2,9 +2,11 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.6
+  NewCops: enable
+  TargetRubyVersion: 3.0
   Exclude:
     - 'app/admin/**/*.rb'
     - 'bin/**/*'
@@ -12,6 +14,7 @@ AllCops:
     - 'db/schema.rb'
     - 'db/migrate/**/*'
     - 'lib/tasks/**/*'
+    - 'node_modules/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
 
@@ -42,18 +45,6 @@ Layout/HashAlignment:
   #   bb: 1
   EnforcedColonStyle: table
 
-Rails/ApplicationController:
-  Enabled: true
-
-Rails/AfterCommitOverride:
-  Enabled: true
-
-Rails/SquishedSQLHeredocs:
-  Enabled: true
-
-Rails/WhereNot:
-  Enabled: true
-
 Style/Documentation:
   Enabled: false
 
@@ -62,6 +53,36 @@ Layout/EmptyLines:
 
 Layout/LineLength:
   Max: 150
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
 
 Metrics/AbcSize:
   Enabled: true
@@ -86,6 +107,9 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
+Naming/VariableNumber:
+  EnforcedStyle: normalcase
+
 Lint/ConstantDefinitionInBlock:
   Enabled: true
 
@@ -95,11 +119,20 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/DuplicateRequire:
   Enabled: true
 
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Lint/EmptyFile:
   Enabled: true
 
 Lint/IdentityComparison:
   Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
 
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
@@ -112,15 +145,6 @@ Lint/UselessTimes:
 
 Layout/BeginEndAlignment:
   Enabled: true
-
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: false
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
 
 #Checks method call operators to not have spaces around them.
 Layout/SpaceAroundMethodCallOperator:
@@ -138,11 +162,98 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Performance/AncestorsInclude:
+  Enabled: true
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/ApplicationController:
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/WhereNot:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: true
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: true
+
+Rails/NegateInclude:
+  Enabled: true
+
+Rails/Pluck:
+  Enabled: true
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: true
+
+Rails/WhereExists:
+  Enabled: true
+
 Style/AccessModifierDeclarations:
   Enabled: false
 
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
 Style/BlockDelimiters:
   Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled:       true
@@ -151,13 +262,25 @@ Style/ClassAndModuleChildren:
 Style/CombinableLoops:
   Enabled: true
 
+Style/ExplicitBlockArgument:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
 
 Style/HashEachMethods:
+  Enabled: true
+
+Style/HashLikeCase:
   Enabled: true
 
 Style/HashTransformKeys:
@@ -169,6 +292,21 @@ Style/HashTransformValues:
 Style/KeywordParametersOrder:
   Enabled: true
 
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantSelfAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
 Style/RedundantReturn:
   Enabled: false
 
@@ -178,13 +316,16 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: false
 
-Style/RedundantSelfAssignment:
+Style/SingleArgumentDig:
   Enabled: true
 
 Style/SlicingWithRange:
   Enabled: true
 
 Style/SoleNestedConditional:
+  Enabled: true
+
+Style/StringConcatenation:
   Enabled: true
 
 Style/TrailingCommaInArguments:
@@ -205,4 +346,34 @@ Style/AndOr:
 # https://github.com/codeclimate/codeclimate-rubocop/blob/master/base_rubocop.yml#L71
 # We use %w[ ], not %w( ) because the former looks like an array
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 70
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MessageChain:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 25
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 10
+
+RSpec/StubbedMock:
+  Enabled: false
+
+RSpec/ContextWording:
   Enabled: false

--- a/lib/templates/PULL_REQUEST_TEMPLATE.md
+++ b/lib/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,60 @@
-## Clubhouse Card Name Here
+[JIRA Story Link]( www.add-link-here )
 
-[Clubhouse Story](link-here)
+Copy and paste JIRA description here
 
-Description from the Clubhouse story
+## Type of change
+Select all that apply:
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Security issue
+- [ ] Infrastructure / network
+- [ ] Refactoring
+- [ ] Functional improvement
+
+## What changed?
+
+#### Before
+
+（エラーの）条件があれば、ここに書いてください。
+You clicked a button and it gave error
+
+#### After
+
+開発後の結果
+When you click the button, it does the thing.
+
 
 ## How to test the PR
 
-- How to test feature 1
-  - Do this
-  - Do that
-  - Success
-- How to test feature 2
-- How to test feature 3
+#### Preparation: 
+テスト用の条件、準備を書いてください。
+Prepare something before tests
+
+#### Tests
+Some page > Subpage (どこでテストをします)
+
+- Select something　（やること）
+- Click button　（やること）
+  - Success when something happens　（結果）
+
+Add screenshot if applicable　（スクショ）
+
+- Select something else　（やること）
+- Click button　（やること）
+  - Success when something else happens　（結果）
+
+Add screenshot if applicable　（スクショ）
+
+---
+
+**Regression:** If there were any substantial changes to view layer code (CSS, JS) or Javascript dependencies were updated do a general smoke test of the feature using the following Windows 7 browsers on Browser Stack. If Chrome only is chosen, only Chrome is tested normally without any other browsers.
+
+Chromeだけが選択だったら、他のブラウザーのテストは不要です。
+
+- [x] Chrome (Latest)
+- [ ] Firefox (Latest)
+- [ ] Internet Explorer 11
 
 ## Deployment Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shuttlerock_shared_config",
-  "version": "0.2.32",
+  "version": "0.3.0",
   "description": "Update shared config for Shuttlerock's projects.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/shuttlerock_shared_config.gemspec
+++ b/shuttlerock_shared_config.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib`.split(/\s+/)
   spec.bindir        = 'exe'
 
-  spec.required_ruby_version = '>= 2.6.6'
+  spec.required_ruby_version = '~> 3.0.0'
 
-  spec.add_dependency 'rake', '>= 12.3', '< 14.0'
-  spec.add_dependency 'rubocop', '>= 0.88', '< 2.0'
+  spec.add_dependency 'rake', '~> 13.0'
+  spec.add_dependency 'rubocop', '~> 1.29'
   spec.add_dependency 'danger', '~> 8.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
# Gem version 0.3.0 release

## Changes

- Updated required ruby version to ~> 3.0.0
- Updated rubocop version to allow current ~> 1.0 version
- Updated rake version to allow current ~> 13.0 version
- Add dependabot config
- Add github actions workflow
- Fix github PR template
- Update CircleCI image names
- Update rubocop config:
  - Add new cops
  - Add rubocop-rspec
  - Enable new cops
  - Target ruby v3


## Deployment Notes

none
